### PR TITLE
Fractional seconds and until inclusion

### DIFF
--- a/sql/pgsql_rrule.sql
+++ b/sql/pgsql_rrule.sql
@@ -463,8 +463,11 @@ BEGIN
 
             WHERE
                 (rule.bymonth IS NULL OR extract(month from ts) = ANY(rule.bymonth)) AND
-                -- NOTE: tsrange defaults to exclusion of the upper bound, so
-                -- specify that the range is inclusive.
+                -- From the second paragraph of page 41 of RFC-5545:
+                --     The UNTIL rule part defines a DATE or DATE-TIME value
+                --     that bounds the recurrence rule in an inclusive manner.
+                -- However, tsrange defaults to exclusion of the upper bound,
+                -- so specify that the range is inclusive.
                 ts <@ tsrange(dtstart, until, '[]')
                 -- TODO: BYSETPOS filter
 

--- a/sql/pgsql_rrule.sql
+++ b/sql/pgsql_rrule.sql
@@ -402,7 +402,9 @@ BEGIN
 --                special expand for MONTHLY if BYMONTH present; otherwise,
 --                special expand for YEARLY.
 
-    until = LEAST(until, rule.until::timestamp);
+    -- Strip fractional seconds from arguments
+    dtstart = date_trunc('second', dtstart);
+    until = date_trunc('second', LEAST(until, rule.until::timestamp));
     wksti = dow(wkst);
     IF extract(dow from dtstart) < wksti THEN
         wksti = wksti-7;

--- a/sql/pgsql_rrule.sql
+++ b/sql/pgsql_rrule.sql
@@ -459,7 +459,9 @@ BEGIN
 
             WHERE
                 (rule.bymonth IS NULL OR extract(month from ts) = ANY(rule.bymonth)) AND
-                ts <@ tsrange(dtstart, until)
+                -- NOTE: tsrange defaults to exclusion of the upper bound, so
+                -- specify that the range is inclusive.
+                ts <@ tsrange(dtstart, until, '[]')
                 -- TODO: BYSETPOS filter
 
             LIMIT rule.count;

--- a/test/expected/fractional-seconds.out
+++ b/test/expected/fractional-seconds.out
@@ -1,23 +1,8 @@
 BEGIN;
-SET LOCAL datestyle to ISO, MDY;
--- Ignore fractional seconds on dtstart
-SELECT * FROM rrule_expand(
+-- Disallow fractional seconds on dtstart
+SELECT * from rrule_expand(
     rrule('FREQ=WEEKLY;COUNT=1'),
     timestamp '2015-01-01 00:00:00.9',
     timestamp '2015-01-02 00:00:00');
-     occurrence      
----------------------
- 2015-01-01 00:00:00
-(1 row)
-
--- Ignore fractional seconds on until
-SELECT * FROM rrule_expand(
-    rrule('FREQ=WEEKLY;COUNT=2'),
-    timestamp '2015-01-01 00:00:01',
-    timestamp '2015-01-08 00:00:00.9');
-     occurrence      
----------------------
- 2015-01-01 00:00:01
-(1 row)
-
+ERROR:  Invalid seconds for dtstart: not an integer
 ROLLBACK;

--- a/test/expected/fractional-seconds.out
+++ b/test/expected/fractional-seconds.out
@@ -1,0 +1,23 @@
+BEGIN;
+SET LOCAL datestyle to ISO, MDY;
+-- Ignore fractional seconds on dtstart
+SELECT * FROM rrule_expand(
+    rrule('FREQ=WEEKLY;COUNT=1'),
+    timestamp '2015-01-01 00:00:00.9',
+    timestamp '2015-01-02 00:00:00');
+     occurrence      
+---------------------
+ 2015-01-01 00:00:00
+(1 row)
+
+-- Ignore fractional seconds on until
+SELECT * FROM rrule_expand(
+    rrule('FREQ=WEEKLY;COUNT=2'),
+    timestamp '2015-01-01 00:00:01',
+    timestamp '2015-01-08 00:00:00.9');
+     occurrence      
+---------------------
+ 2015-01-01 00:00:01
+(1 row)
+
+ROLLBACK;

--- a/test/expected/until-inclusive.out
+++ b/test/expected/until-inclusive.out
@@ -1,0 +1,14 @@
+BEGIN;
+SET LOCAL datestyle to ISO, MDY;
+-- The until date/timestamp should be included if it matches the rrule
+SELECT * FROM rrule_expand(
+    rrule('FREQ=WEEKLY;COUNT=2'),
+    timestamp '2015-01-01 00:00:00',
+    timestamp '2015-01-08 00:00:00');
+     occurrence      
+---------------------
+ 2015-01-01 00:00:00
+ 2015-01-08 00:00:00
+(2 rows)
+
+ROLLBACK;

--- a/test/sql/fractional-seconds.sql
+++ b/test/sql/fractional-seconds.sql
@@ -1,0 +1,16 @@
+BEGIN;
+SET LOCAL datestyle to ISO, MDY;
+
+-- Ignore fractional seconds on dtstart
+SELECT * FROM rrule_expand(
+    rrule('FREQ=WEEKLY;COUNT=1'),
+    timestamp '2015-01-01 00:00:00.9',
+    timestamp '2015-01-02 00:00:00');
+
+-- Ignore fractional seconds on until
+SELECT * FROM rrule_expand(
+    rrule('FREQ=WEEKLY;COUNT=2'),
+    timestamp '2015-01-01 00:00:01',
+    timestamp '2015-01-08 00:00:00.9');
+
+ROLLBACK;

--- a/test/sql/fractional-seconds.sql
+++ b/test/sql/fractional-seconds.sql
@@ -1,16 +1,9 @@
 BEGIN;
-SET LOCAL datestyle to ISO, MDY;
 
--- Ignore fractional seconds on dtstart
-SELECT * FROM rrule_expand(
+-- Disallow fractional seconds on dtstart
+SELECT * from rrule_expand(
     rrule('FREQ=WEEKLY;COUNT=1'),
     timestamp '2015-01-01 00:00:00.9',
     timestamp '2015-01-02 00:00:00');
-
--- Ignore fractional seconds on until
-SELECT * FROM rrule_expand(
-    rrule('FREQ=WEEKLY;COUNT=2'),
-    timestamp '2015-01-01 00:00:01',
-    timestamp '2015-01-08 00:00:00.9');
 
 ROLLBACK;

--- a/test/sql/until-inclusive.sql
+++ b/test/sql/until-inclusive.sql
@@ -1,0 +1,10 @@
+BEGIN;
+SET LOCAL datestyle to ISO, MDY;
+
+-- The until date/timestamp should be included if it matches the rrule
+SELECT * FROM rrule_expand(
+    rrule('FREQ=WEEKLY;COUNT=2'),
+    timestamp '2015-01-01 00:00:00',
+    timestamp '2015-01-08 00:00:00');
+
+ROLLBACK;


### PR DESCRIPTION
This branch addresses two issues:
- A fractional seconds component of less than 0.5 on `dtstart` would cause the first occurrence to disappear (this seems to be the most severe of several edge cases where `dtstart` or `until` contain fractional seconds).
- `until` was excluded from the occurrences even if it matched the pattern.
